### PR TITLE
Add Mermaid support to MkDocs configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ site
 .DS_Store
 .cache
 myenv
+.python-version

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,11 @@ theme:
 markdown_extensions:
   - toc:
       toc_depth: 2
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format      
 
 extra_css:
   - css/margo.css

--- a/system-design/orchestration/workload/workload-orchestration-edge-onboarding.md
+++ b/system-design/orchestration/workload/workload-orchestration-edge-onboarding.md
@@ -13,7 +13,56 @@ In order for the workload orchestration solution to manage the edge device's wor
 1. The device's management client receives the URL for the Git repository containing its desired state and an associated access token for authentication
 1. The [device capabilities](./device-capability-reporting.md) information is sent from the device to the workload orchestration web service using the [Device API](../../margo-api-reference/workload-api/device-api/device-capabilities.md)
 
-![Margo Management Interface Operational Flow Diagram (svg)](../../figures/margo-interface-generic.drawio.svg)
+``` mermaid
+sequenceDiagram
+    %%{init: {'sequence': {'mirrorActors': false}}}%%
+    autonumber
+    participant device as Device
+    actor user as End User
+    participant rendezvous as Rendezvous Server
+    participant wos as WOS
+    participant git as WOS: Device Git Repo   
+    note over device, git: Workload orchestration onboarding
+    user -->> device: Get device id and cert
+    activate device
+        device -->> user: return
+    deactivate device
+    user -->> wos: Provides device id and cert to pre-register device in end user's tenant 🔐
+     
+    %%note over device, rendezvous: FIDO
+    user -->> rendezvous: Provides WOS URL
+    device -->>+ rendezvous: Looks up WOS URL
+    rendezvous -->>- device: return
+    device -->>+ wos: Request WOS' public signing cert 🔓
+    wos -->- device: return
+    device -->>+ wos: Send onboard request, device id and certificate 🔓
+    wos -->> wos: Vaidates device id and cert with onboarding registry
+    wos -->- device: returns URL to check onboarding status
+    
+    loop until onboarding status is active   
+        device -->>+ wos: Checks onboarding status providing device id and certificate 🔓
+        wos -->> wos: Validates device id and cert with onboarding registry
+        wos -->- device: returns in progress
+    end
+    device -->>+ wos: Checks onboarding status providing device id and certificate 🔓
+    wos -->> wos: Validates device id and cert with onboarding registry
+    wos -->- device: returns git repo URL and GitOps token, encrypted client id, encrypted client secret
+    
+    device -->> wos: Uploads device capabilities
+    note over device, git: Workload deployment
+    loop Until end of time
+        device -->>+ git: Checks for updates to desired state 🔐
+        git -->>- device: return
+        opt
+            device -->> wos: Requests new GitOps token 🔐
+            wos -->> device: return
+        end
+        device -->> device: Applies new desired state
+        device -->> wos: Sends state 🔐
+        device -->> wos: Sends state 🔐
+        device -->> wos: Sends final state 🔐
+    end    
+```
 > Action: FIDO Device onboarding has not been finalized as the standard onboarding solution. Further discussion/investigations are needed. 
 
 ### Configuring the Workload Orchestration Web Service URL
@@ -68,3 +117,4 @@ Once the edge device has a message prepared for the workload orchestration web s
 
 - Git access tokens shall be provided to the device's management client. These access tokens MUST be tied to a dedicated non-user account for access where credentials are frequently rotated and short lived.
 - Need to support accessing rotations of tokens
+


### PR DESCRIPTION
### Description

Enabled Mermaid diagrams in mkdocs.yml by adding the necessary plugin. Provided a working example of a Mermaid diagram to demonstrate its usage and clarify integration.

- Updated .gitignore as needed for related files
- Modified 'workload-orchestration-edge-onboarding.md' to include a diagram example

#### Issues Addressed

mkdocs has now Mermaid support

#### Change Type

Please select the relevant options:

- [ ] Fix (change that resolves an issue)
- [x] New enhancement (change that adds specification content)
- [ ] Content edits (change that edits existing content)

#### Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document.
- [x] My changes adhere to the established patterns, and best practices.
